### PR TITLE
Allow pure web component mounting

### DIFF
--- a/playwright-ct-web/registerSource.mjs
+++ b/playwright-ct-web/registerSource.mjs
@@ -27,6 +27,14 @@ function __pwUpdateProps(webComponent, props = {}) {
 /**
  * @param {HTMLElement} webComponent
  */
+function __pwUpdateAttributes(webComponent, attributes = {}) {
+  for (const [key, value] of Object.entries(attributes))
+    webComponent.setAttribute(key, typeof value === 'boolean' ? '' : value);
+}
+
+/**
+ * @param {HTMLElement} webComponent
+ */
 function __pwRemoveEvents(webComponent, events = {}) {
   for (const [key] of Object.entries(events)) {
     webComponent.removeEventListener(key, listeners.get(key));
@@ -125,6 +133,7 @@ window.playwrightMount = async (component, rootElement, hooksConfig) => {
 
   const webComponent = __pwCreateComponent(component);
   __pwUpdateProps(webComponent, component.options?.props);
+  __pwUpdateAttributes(webComponent, component.options?.attributes);
   __pwUpdateSlots(webComponent, component.options?.slots);
   __pwUpdateEvents(webComponent, component.options?.on);
 
@@ -145,6 +154,7 @@ window.playwrightUpdate = async (rootElement, component) => {
   if (!webComponent) throw new Error('Component was not mounted');
 
   __pwUpdateProps(webComponent, component.options?.props);
+  __pwUpdateAttributes(webComponent, component.options?.attributes);
   __pwUpdateSlots(webComponent, component.options?.slots);
   __pwRemoveEvents(webComponent, component.options?.on);
   __pwUpdateEvents(webComponent, component.options?.on);


### PR DESCRIPTION
For most web component test cases (in my experience anyway) - you simply want to mount the web component the same way you would mount it in an app, i.e. as a string:
``<my-web-component some-attribute="foo">bar</my-web-component>``
This (very hacky) fix allows the above option whilst keeping the existing behaviour if necessary.