### PR TITLE
chore: remove vite as dependency

### DIFF
--- a/playwright-ct-web/index.d.ts
+++ b/playwright-ct-web/index.d.ts
@@ -14,26 +14,9 @@
  * limitations under the License.
  */
 
-import type {
-  TestType,
-  PlaywrightTestArgs,
-  PlaywrightTestConfig as BasePlaywrightTestConfig,
-  PlaywrightTestOptions,
-  PlaywrightWorkerArgs,
-  PlaywrightWorkerOptions,
-  Locator,
-} from '@playwright/test';
-import type { JsonObject, JsonValue } from '@playwright/experimental-ct-core/types/component';
-import type { InlineConfig } from 'vite';
-
-export type PlaywrightTestConfig<T = {}, W = {}> = Omit<BasePlaywrightTestConfig<T, W>, 'use'> & {
-  use?: BasePlaywrightTestConfig<T, W>['use'] & {
-    ctPort?: number;
-    ctTemplateDir?: string;
-    ctCacheDir?: string;
-    ctViteConfig?: InlineConfig | (() => Promise<InlineConfig>);
-  };
-};
+import type { Locator } from '@playwright/test';
+import type { JsonObject, JsonValue, } from '@playwright/experimental-ct-core/types/component';
+import type { TestType } from '@playwright/experimental-ct-core';
 
 type PickByValue<T, ValueType> = Pick<T, { [Key in keyof T]-?: T[Key] extends ValueType ? Key : never }[keyof T]>;
 
@@ -66,20 +49,12 @@ interface MountResult<Component extends HTMLElement> extends Locator {
   }): Promise<void>;
 }
 
-export interface ComponentFixtures {
+export const test: TestType<{
   mount<HooksConfig extends JsonObject, Component extends HTMLElement = HTMLElement>(
     component: new (...args: any[]) => Component,
     options?: MountOptions<HooksConfig, Component>
   ): Promise<MountResult<Component>>;
-}
+}>;
 
-export const test: TestType<
-  PlaywrightTestArgs & PlaywrightTestOptions & ComponentFixtures,
-  PlaywrightWorkerArgs & PlaywrightWorkerOptions
->;
-
-export function defineConfig(config: PlaywrightTestConfig): PlaywrightTestConfig;
-export function defineConfig<T>(config: PlaywrightTestConfig<T>): PlaywrightTestConfig<T>;
-export function defineConfig<T, W>(config: PlaywrightTestConfig<T, W>): PlaywrightTestConfig<T, W>;
-
+export { defineConfig, PlaywrightTestConfig } from '@playwright/experimental-ct-core';
 export { expect, devices } from '@playwright/test';

--- a/playwright-ct-web/package.json
+++ b/playwright-ct-web/package.json
@@ -43,7 +43,6 @@
     }
   },
   "dependencies": {
-    "vite": "^4.4.7",
     "@playwright/experimental-ct-core": "^1.41.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@playwright/experimental-ct-core':
         specifier: ^1.41.0
         version: 1.41.0
-      vite:
-        specifier: ^4.4.7
-        version: 4.4.7
     devDependencies:
       '@playwright/test':
         specifier: 1.41.0
@@ -367,6 +364,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup@3.29.4:
     resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
@@ -419,6 +417,7 @@ packages:
       rollup: 3.27.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vite@4.5.1:
     resolution: {integrity: sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==}


### PR DESCRIPTION
closes: https://github.com/sand4rt/playwright-ct-web/issues/2 _(`@playwright/experimental-ct-core` still uses Vite tho)_