### PR TITLE
feat(playwright-ct-web): beforeMount hook receives the component constructor type, in line with other Playwright CT modules

### DIFF
--- a/ct-web-lit/playwright/index.ts
+++ b/ct-web-lit/playwright/index.ts
@@ -6,10 +6,11 @@ export type HooksConfig = {
   route: string;
 }
 
-beforeMount<HooksConfig>(async ({ hooksConfig }) => {
+beforeMount<HooksConfig, { register?: (prefix: string) => void }>(async ({ hooksConfig, App }) => {
   console.log(`Before mount: ${JSON.stringify(hooksConfig)}`);
+  App.register?.call(null, 'my-prefixed-');
 });
-  
+
 afterMount<HooksConfig>(async () => {
   console.log(`After mount`);
 });

--- a/ct-web-lit/src/components/CustomizableTagName.ts
+++ b/ct-web-lit/src/components/CustomizableTagName.ts
@@ -1,0 +1,13 @@
+import { LitElement, html } from 'lit';
+
+export class CustomizableTagName extends LitElement {
+    private static tagName = `customizable-tag-name-component`;
+
+    static register(prefix: string = '') {
+        customElements.define(`${prefix}${CustomizableTagName.tagName}`, CustomizableTagName);
+    }
+
+    render() {
+        return html`<div>test</div>`;
+    }
+}

--- a/ct-web-lit/tests/customizable.spec.ts
+++ b/ct-web-lit/tests/customizable.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@sand4rt/experimental-ct-web';
+import { CustomizableTagName } from '@/components/CustomizableTagName';
+
+test('allows customizing the mount function', async ({ mount }) => {
+  const component = await mount(CustomizableTagName);
+  const tagName = await component.evaluate(el => el.tagName);
+  expect(tagName).toEqual('MY-PREFIXED-CUSTOMIZABLE-TAG-NAME-COMPONENT');
+});

--- a/playwright-ct-web/hooks.d.ts
+++ b/playwright-ct-web/hooks.d.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-export declare function beforeMount<HooksConfig>(
-  callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>,
+export declare function beforeMount<HooksConfig, StaticProperties extends Record<string, any> = {}>(
+  callback: (params: {
+      hooksConfig?: HooksConfig;
+      App: { new (...args: any[]): HTMLElement } & StaticProperties;
+  }) => Promise<void>
 ): void;
-export declare function afterMount<HooksConfig>(
-  callback: (params: { hooksConfig?: HooksConfig }) => Promise<void>,
+
+export declare function afterMount<HooksConfig, Component extends HTMLElement = HTMLElement>(
+  callback: (params: {
+      hooksConfig?: HooksConfig;
+      element: Component
+  }) => Promise<void>,
 ): void;

--- a/playwright-ct-web/registerSource.mjs
+++ b/playwright-ct-web/registerSource.mjs
@@ -115,15 +115,15 @@ window.playwrightMount = async (component, rootElement, hooksConfig) => {
   if (component.__pw_type === 'jsx')
     throw new Error('JSX mount notation is not supported');
 
-  const webComponent = __pwCreateComponent(component);
-
   for (const hook of window['__pw_hooks_before_mount'] || [])
-    await hook({ hooksConfig });
+    await hook({ hooksConfig, App: component.type });
+
+  const webComponent = __pwCreateComponent(component);
 
   rootElement.appendChild(webComponent);
 
   for (const hook of window['__pw_hooks_after_mount'] || [])
-    await hook({ hooksConfig });
+    await hook({ hooksConfig, component: webComponent });
 };
 
 window.playwrightUpdate = async (rootElement, component) => {


### PR DESCRIPTION
Hi @sand4rt! I want to propose extending the `beforeMount` function to receive the component constructor function and the `afterMount` to receive the constructed element.

This change aligns `playwright-ct-web` with other Playwright component testing modules that have this behaviour:
- [`playwright-ct-react`](https://github.com/microsoft/playwright/blob/b5fe029c1b400464f3c223a696a47cd0a1c01ab9/packages/playwright-ct-react/hooks.d.ts)
- [`playwright-ct-svelte`](https://github.com/microsoft/playwright/blob/b5fe029c1b400464f3c223a696a47cd0a1c01ab9/packages/playwright-ct-svelte/hooks.d.ts)
- [`playwright-ct-vue`](https://github.com/microsoft/playwright/blob/b5fe029c1b400464f3c223a696a47cd0a1c01ab9/packages/playwright-ct-vue/hooks.d.ts)

This feature will also enable Lit and web components with static methods to self-register the component e.g. with a custom prefix.