### PR TITLE
chore(release): fixed version and corrected semantic release config

### DIFF
--- a/playwright-ct-web/.releaserc.json
+++ b/playwright-ct-web/.releaserc.json
@@ -13,7 +13,7 @@
       { "prepareCmd": "git ls-files -m -o" }
     ],
     [ "@semantic-release/git", {
-      "assets": ["playwright-ct-web/package.json"],
+      "assets": ["package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     [ "@semantic-release/npm", {

--- a/playwright-ct-web/package.json
+++ b/playwright-ct-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sand4rt/experimental-ct-web",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "description": "Playwright Component Testing for Web Components",
   "homepage": "https://playwright.dev",
   "repository": {


### PR DESCRIPTION
@sand4rt - I found the issue in the semantic-release configuration. It was the path to `package.json`. See https://github.com/sand4rt/playwright-ct-web/actions/runs/15745543071/job/44380938029#step:6:81